### PR TITLE
feat: features added to support loki release process

### DIFF
--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -73,6 +73,8 @@ interface VersioningArgs {
   latestTagVersion?: string;
   latestTagSha?: string;
   latestTagName?: string;
+
+  includeAllReleases?: boolean;
 }
 
 interface ManifestConfigArgs {
@@ -345,6 +347,12 @@ function pullRequestStrategyOptions(yargs: yargs.Argv): yargs.Argv {
       describe: 'Override the detected latest tag name',
       type: 'string',
     })
+    .option('include-all-releases', {
+      describe:
+        'Include release shas from all branches when determining latest release',
+      default: false,
+      type: 'boolean',
+    })
     .middleware(_argv => {
       const argv = _argv as CreatePullRequestArgs;
 
@@ -471,6 +479,7 @@ const createReleasePullRequestCommand: yargs.CommandModule<
           versionFile: argv.versionFile,
           includeComponentInTag: argv.monorepoTags,
           includeVInTag: argv.includeVInTags,
+          includeAllReleases: argv.includeAllReleases,
         },
         extractManifestOptions(argv),
         argv.path
@@ -489,7 +498,9 @@ const createReleasePullRequestCommand: yargs.CommandModule<
     }
 
     if (argv.dryRun) {
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests(
+        argv.includeAllReleases
+      );
       console.log(`Would open ${pullRequests.length} pull requests`);
       console.log('fork:', manifest.fork);
       for (const pullRequest of pullRequests) {
@@ -524,7 +535,9 @@ const createReleasePullRequestCommand: yargs.CommandModule<
         }
       }
     } else {
-      const pullRequestNumbers = await manifest.createPullRequests();
+      const pullRequestNumbers = await manifest.createPullRequests(
+        argv.includeAllReleases
+      );
       console.log(pullRequestNumbers);
     }
   },

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -74,7 +74,7 @@ interface VersioningArgs {
   latestTagSha?: string;
   latestTagName?: string;
 
-  includeAllReleases?: boolean;
+  considerAllBranches?: boolean;
 }
 
 interface ManifestConfigArgs {
@@ -347,9 +347,9 @@ function pullRequestStrategyOptions(yargs: yargs.Argv): yargs.Argv {
       describe: 'Override the detected latest tag name',
       type: 'string',
     })
-    .option('include-all-releases', {
+    .option('consider-all-branches', {
       describe:
-        'Include release shas from all branches when determining latest release',
+        'Consider commits from all branches when determining changes for the latest release',
       default: false,
       type: 'boolean',
     })
@@ -479,7 +479,7 @@ const createReleasePullRequestCommand: yargs.CommandModule<
           versionFile: argv.versionFile,
           includeComponentInTag: argv.monorepoTags,
           includeVInTag: argv.includeVInTags,
-          includeAllReleases: argv.includeAllReleases,
+          considerAllBranches: argv.considerAllBranches,
         },
         extractManifestOptions(argv),
         argv.path
@@ -499,7 +499,7 @@ const createReleasePullRequestCommand: yargs.CommandModule<
 
     if (argv.dryRun) {
       const pullRequests = await manifest.buildPullRequests(
-        argv.includeAllReleases
+        argv.considerAllBranches
       );
       console.log(`Would open ${pullRequests.length} pull requests`);
       console.log('fork:', manifest.fork);
@@ -536,7 +536,7 @@ const createReleasePullRequestCommand: yargs.CommandModule<
       }
     } else {
       const pullRequestNumbers = await manifest.createPullRequests(
-        argv.includeAllReleases
+        argv.considerAllBranches
       );
       console.log(pullRequestNumbers);
     }

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -92,6 +92,7 @@ interface ReleaseArgs {
   releaseLabel?: string;
   snapshotLabel?: string;
   label?: string;
+  shasToTag?: string;
 }
 
 interface PullRequestArgs {
@@ -235,6 +236,11 @@ function releaseOptions(yargs: yargs.Argv): yargs.Argv {
       describe:
         'set a java snapshot pull request label other than "autorelease: snapshot"',
       default: 'autorelease: snapshot',
+      type: 'string',
+    })
+    .option('shas-to-tag', {
+      describe:
+        'a comma separated list of PR numbers and the corresponding sha to tag for that release in the format "1234:abc123,5678:def456"',
       type: 'string',
     });
 }
@@ -595,6 +601,7 @@ const createReleaseCommand: yargs.CommandModule<{}, CreateReleaseArgs> = {
           prerelease: argv.prerelease,
           includeComponentInTag: argv.monorepoTags,
           includeVInTag: argv.includeVInTags,
+          shasToTag: argv.shasToTag,
         },
         extractManifestOptions(argv),
         argv.path,

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -100,6 +100,7 @@ interface PullRequestArgs {
   skipLabeling?: boolean;
   signoff?: string;
   separatePullRequests?: boolean;
+  groupPullRequestTitlePattern?: string;
 }
 
 interface PullRequestStrategyArgs {

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -851,8 +851,10 @@ export const parser = yargs
   })
   .middleware(argv => {
     if (argv.trace) {
+      console.log('setting trace logging')
       setLogger(new CheckpointLogger(true, true));
     } else if (argv.debug) {
+      console.log('setting debug logging')
       setLogger(new CheckpointLogger(true));
     }
   })

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -30,6 +30,7 @@ import {
 } from '../factory';
 import {Bootstrapper} from '../bootstrapper';
 import {createPatch} from 'diff';
+import {writeFileSync} from 'fs';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const parseGithubRepoUrl = require('parse-github-repo-url');
@@ -43,6 +44,7 @@ interface ErrorObject {
 
 interface GitHubArgs {
   dryRun?: boolean;
+  outputDryRun?: string;
   trace?: boolean;
   repoUrl?: string;
   token?: string;
@@ -186,6 +188,10 @@ function gitHubOptions(yargs: yargs.Argv): yargs.Argv {
       describe: 'Prepare but do not take action',
       type: 'boolean',
       default: false,
+    })
+    .option('output-dry-run', {
+      describe: 'Where to output the dry-run results as JSON',
+      type: 'string',
     })
     .middleware(_argv => {
       const argv = _argv as GitHubArgs;
@@ -533,6 +539,10 @@ const createReleasePullRequestCommand: yargs.CommandModule<
             }
           }
         }
+      }
+
+      if (argv.outputDryRun) {
+        writeFileSync(argv.outputDryRun, JSON.stringify(pullRequests, null, 2));
       }
     } else {
       const pullRequestNumbers = await manifest.createPullRequests(

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -860,10 +860,8 @@ export const parser = yargs
   })
   .middleware(argv => {
     if (argv.trace) {
-      console.log('setting trace logging');
       setLogger(new CheckpointLogger(true, true));
     } else if (argv.debug) {
-      console.log('setting debug logging');
       setLogger(new CheckpointLogger(true));
     }
   })

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -99,6 +99,7 @@ interface PullRequestArgs {
   label?: string;
   skipLabeling?: boolean;
   signoff?: string;
+  separatePullRequests?: boolean;
 }
 
 interface PullRequestStrategyArgs {
@@ -263,6 +264,12 @@ function pullRequestOptions(yargs: yargs.Argv): yargs.Argv {
       describe:
         'Add Signed-off-by line at the end of the commit log message using the user and email provided. (format "Name <email@example.com>").',
       type: 'string',
+    })
+    .option('separate-pull-requests', {
+      describe:
+        'create separate pull requests for each package instead of a single manifest release pull request',
+      type: 'boolean',
+      default: true,
     });
 }
 
@@ -919,6 +926,9 @@ function extractManifestOptions(
   }
   if ('draftPullRequest' in argv && argv.draftPullRequest !== undefined) {
     manifestOptions.draftPullRequest = argv.draftPullRequest;
+  }
+  if ( 'separatePullRequests' in argv && argv.separatePullRequests !== undefined) {
+    manifestOptions.separatePullRequests = argv.separatePullRequests;
   }
   return manifestOptions;
 }

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -495,7 +495,8 @@ const createReleasePullRequestCommand: yargs.CommandModule<
           considerAllBranches: argv.considerAllBranches,
         },
         extractManifestOptions(argv),
-        argv.path
+        argv.path,
+        argv.manifestFile
       );
     } else {
       const manifestOptions = extractManifestOptions(argv);
@@ -591,7 +592,8 @@ const createReleaseCommand: yargs.CommandModule<{}, CreateReleaseArgs> = {
           includeVInTag: argv.includeVInTags,
         },
         extractManifestOptions(argv),
-        argv.path
+        argv.path,
+        argv.manifestFile
       );
     } else {
       const manifestOptions = extractManifestOptions(argv);
@@ -858,10 +860,10 @@ export const parser = yargs
   })
   .middleware(argv => {
     if (argv.trace) {
-      console.log('setting trace logging')
+      console.log('setting trace logging');
       setLogger(new CheckpointLogger(true, true));
     } else if (argv.debug) {
-      console.log('setting debug logging')
+      console.log('setting debug logging');
       setLogger(new CheckpointLogger(true));
     }
   })
@@ -927,7 +929,10 @@ function extractManifestOptions(
   if ('draftPullRequest' in argv && argv.draftPullRequest !== undefined) {
     manifestOptions.draftPullRequest = argv.draftPullRequest;
   }
-  if ( 'separatePullRequests' in argv && argv.separatePullRequests !== undefined) {
+  if (
+    'separatePullRequests' in argv &&
+    argv.separatePullRequests !== undefined
+  ) {
     manifestOptions.separatePullRequests = argv.separatePullRequests;
   }
   return manifestOptions;

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -266,10 +266,14 @@ function pullRequestOptions(yargs: yargs.Argv): yargs.Argv {
       type: 'string',
     })
     .option('separate-pull-requests', {
-      describe:
-        'create separate pull requests for each package instead of a single manifest release pull request',
+      describe: 'open a separate release pull request for each component',
       type: 'boolean',
       default: true,
+    })
+    .option('group-pull-request-title-pattern', {
+      describe:
+        'when grouping multiple release pull requests use this pattern for the title',
+      type: 'string',
     });
 }
 
@@ -932,6 +936,12 @@ function extractManifestOptions(
     argv.separatePullRequests !== undefined
   ) {
     manifestOptions.separatePullRequests = argv.separatePullRequests;
+  }
+  if (
+    'groupPullRequestTitlePattern' in argv &&
+    argv.groupPullRequestTitlePattern
+  ) {
+    manifestOptions.groupPullRequestTitlePattern = argv.groupPullRequestTitlePattern;
   }
   return manifestOptions;
 }

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -44,7 +44,7 @@ interface ErrorObject {
 
 interface GitHubArgs {
   dryRun?: boolean;
-  outputDryRun?: string;
+  dryRunOutput?: string;
   trace?: boolean;
   repoUrl?: string;
   token?: string;
@@ -189,7 +189,7 @@ function gitHubOptions(yargs: yargs.Argv): yargs.Argv {
       type: 'boolean',
       default: false,
     })
-    .option('output-dry-run', {
+    .option('dry-run-output', {
       describe: 'Where to output the dry-run results as JSON',
       type: 'string',
     })
@@ -541,8 +541,8 @@ const createReleasePullRequestCommand: yargs.CommandModule<
         }
       }
 
-      if (argv.outputDryRun) {
-        writeFileSync(argv.outputDryRun, JSON.stringify(pullRequests, null, 2));
+      if (argv.dryRunOutput) {
+        writeFileSync(argv.dryRunOutput, JSON.stringify(pullRequests, null, 2));
       }
     } else {
       const pullRequestNumbers = await manifest.createPullRequests(

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 import {RequestError} from '@octokit/request-error';
-import {RequestError as RequestErrorBody} from '@octokit/types';
+import {
+  RequestError as RequestErrorBody,
+  ResponseHeaders,
+} from '@octokit/types';
 
 interface SingleError {
   resource: string;
@@ -45,6 +48,7 @@ export class GitHubAPIError extends Error {
   body: RequestErrorBody | undefined;
   status: number;
   cause?: Error;
+  headers?: ResponseHeaders;
   constructor(requestError: RequestError, message?: string) {
     super(message ?? requestError.message);
     this.status = requestError.status;
@@ -52,6 +56,7 @@ export class GitHubAPIError extends Error {
     this.name = GitHubAPIError.name;
     this.cause = requestError;
     this.stack = requestError.stack;
+    this.headers = requestError.response?.headers;
   }
 
   static parseErrorBody(

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -598,7 +598,7 @@ export class Manifest {
     const releasePullRequestsBySha: Record<string, PullRequest> = {};
     // only consider commits across all branches when there has been a previous release
     // otherwise, there would be nothing to compare against
-    if (considerAllBranches && releasesByPath.length > 0) {
+    if (considerAllBranches && Object.keys(releasesByPath).length > 0) {
       for (const path in releasesByPath) {
         const release = releasesByPath[path];
         this.logger.info(

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -818,7 +818,6 @@ export class Manifest {
     // Combine pull requests into 1 unless configured for separate
     // pull requests
     if (!this.separatePullRequests) {
-      this.logger.debug('combining pull requests into one');
       const mergeOptions: MergeOptions = {
         pullRequestTitlePattern: this.groupPullRequestTitlePattern,
       };
@@ -846,10 +845,6 @@ export class Manifest {
           this.repositoryConfig,
           mergeOptions
         )
-      );
-    } else {
-      this.logger.debug(
-        `creating separate pull requests because separate pull requests is ${this.separatePullRequests}`
       );
     }
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -807,6 +807,7 @@ export class Manifest {
     // Combine pull requests into 1 unless configured for separate
     // pull requests
     if (!this.separatePullRequests) {
+      this.logger.debug(`combining pull requests into one`)
       const mergeOptions: MergeOptions = {
         pullRequestTitlePattern: this.groupPullRequestTitlePattern,
       };
@@ -835,6 +836,8 @@ export class Manifest {
           mergeOptions
         )
       );
+    } else {
+      this.logger.debug(`creating separate pull requests becuase separate pull requests is ${this.separatePullRequests}`)
     }
 
     for (const plugin of this.plugins) {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -116,6 +116,7 @@ export interface ReleaserConfig {
   extraLabels?: string[];
   initialVersion?: string;
   considerAllBranches?: boolean;
+  shasToTag?: string;
 
   // Changelog options
   changelogSections?: ChangelogSection[];
@@ -1202,7 +1203,18 @@ export class Manifest {
         this.logger.debug(`type: ${config.releaseType}`);
         this.logger.debug(`targetBranch: ${this.targetBranch}`);
         const strategy = strategiesByPath[path];
+
+        const shasToTag = (config.shasToTag?.split(',') || []).reduce(
+          (memo: Map<number, string>, sha: string) => {
+            const parts = sha.split(':');
+            memo.set(parseInt(parts[0]), parts[1]);
+            return memo;
+          },
+          new Map<number, string>()
+        );
+
         const releases = await strategy.buildReleases(pullRequest, {
+          shasToTag,
           groupPullRequestTitlePattern: this.groupPullRequestTitlePattern,
         });
         for (const release of releases) {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1205,9 +1205,13 @@ export class Manifest {
         const strategy = strategiesByPath[path];
 
         const shasToTag = (config.shasToTag?.split(',') || []).reduce(
-          (memo: Map<number, string>, sha: string) => {
-            const parts = sha.split(':');
-            memo.set(parseInt(parts[0]), parts[1]);
+          (memo: Map<number, string>, prNumAndSha: string) => {
+            const parts = prNumAndSha.split(':');
+            const prNumber = parts[0];
+            const sha = parts[1];
+
+            this.logger.info(`Using ${sha} as release for PR #${prNumber}`);
+            memo.set(parseInt(prNumber), sha);
             return memo;
           },
           new Map<number, string>()
@@ -1218,6 +1222,9 @@ export class Manifest {
           groupPullRequestTitlePattern: this.groupPullRequestTitlePattern,
         });
         for (const release of releases) {
+          this.logger.info(
+            `Tagging ${release.sha} as release for version ${release.tag.version}`
+          );
           candidateReleases.push({
             ...release,
             path,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -176,6 +176,7 @@ interface ReleaserConfigJson {
   'skip-snapshot'?: boolean; // Java-only
   'initial-version'?: string;
   'exclude-paths'?: string[]; // manifest-only
+  'consider-all-branches'?: boolean;
 }
 
 export interface ManifestOptions {
@@ -1409,6 +1410,7 @@ function extractReleaserConfig(
     skipSnapshot: config['skip-snapshot'],
     initialVersion: config['initial-version'],
     excludePaths: config['exclude-paths'],
+    considerAllBranches: config['consider-all-branches'],
   };
 }
 

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -42,6 +42,7 @@ import {GenericXml} from '../updaters/generic-xml';
 import {PomXml} from '../updaters/java/pom-xml';
 import {GenericYaml} from '../updaters/generic-yaml';
 import {GenericToml} from '../updaters/generic-toml';
+import {merge} from 'diff';
 
 const DEFAULT_CHANGELOG_PATH = 'CHANGELOG.md';
 
@@ -659,6 +660,14 @@ export abstract class BaseStrategy implements Strategy {
       return;
     }
 
+    const _sha: string | undefined = options?.shasToTag?.get(
+      mergedPullRequest.number
+    );
+    const shaToTag: string =
+      _sha !== undefined && _sha !== null && _sha
+        ? _sha
+        : mergedPullRequest.sha;
+
     const tag = new TagName(
       version,
       this.includeComponentInTag ? component : undefined,
@@ -673,7 +682,7 @@ export abstract class BaseStrategy implements Strategy {
       name: releaseName,
       tag,
       notes: notes || '',
-      sha: mergedPullRequest.sha,
+      sha: shaToTag,
     };
   }
 

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -22,6 +22,7 @@ import {Version} from './version';
 
 export interface BuildReleaseOptions {
   groupPullRequestTitlePattern?: string;
+  shasToTag: Map<number, string>;
 }
 
 export interface BumpReleaseOptions {


### PR DESCRIPTION
This PR brings in the changes we needed for make release please work with Loki, including

* looking across multiple branches for previous releases when creating release notes (since we release from release branches)
* enable outputting dry run output to a json file so the version can be determined before building artifacts (and without needing to create a release PR)
* allow `separate-pull-requests` and manfiest file to be specified from command line and used when using release please in `fromConfig` mode (ie. via command line flags rather than a config file)
* tag the correct sha (the one before the merge of the release PR)

Fixes #[2202](https://github.com/googleapis/release-please/issues/2202)🦕
