### PR TITLE
fix(pack): use prepack + recursive files glob for yarn 4 git-dep consumers

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,8 +5,11 @@ enableGlobalCache: false
 # enableScripts: do not run install/preinstall/postinstall scripts from
 # third-party packages. Yarn 4 already defaults to false, but we set it
 # explicitly so the intent is recorded and survives future default changes.
-# Workspace-local scripts (our own package.json "prepare", "pretest", etc.)
-# still run — yarn only blocks scripts from dependencies.
+# Note: yarn 4 also does NOT auto-run a workspace's own "prepare" on
+# `yarn install` (regression vs yarn classic / npm). For build steps that
+# must run before `yarn pack` — including the implicit pack that yarn
+# performs when resolving this repo as a git dependency in a consumer —
+# use "prepack" instead of "prepare". See package.json.
 enableScripts: false
 
 # npmMinimalAgeGate: refuse to install package versions younger than this

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,11 +5,6 @@ enableGlobalCache: false
 # enableScripts: do not run install/preinstall/postinstall scripts from
 # third-party packages. Yarn 4 already defaults to false, but we set it
 # explicitly so the intent is recorded and survives future default changes.
-# Note: yarn 4 also does NOT auto-run a workspace's own "prepare" on
-# `yarn install` (regression vs yarn classic / npm). For build steps that
-# must run before `yarn pack` — including the implicit pack that yarn
-# performs when resolving this repo as a git dependency in a consumer —
-# use "prepack" instead of "prepare". See package.json.
 enableScripts: false
 
 # npmMinimalAgeGate: refuse to install package versions younger than this

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
     "docs": "echo add docs tests",
     "test:snap": "yarn compile && cross-env SNAPSHOT_UPDATE=1 LC_ALL=en c8 mocha --node-option no-experimental-fetch --recursive --timeout=5000 build/test",
     "clean": "gts clean",
-    "prepare": "yarn compile",
+    "prepack": "tsc -p .",
     "lint": "gts check",
     "compile": "tsc -p .",
     "fix": "gts fix",
     "pretest": "yarn compile"
   },
   "files": [
-    "build/src",
+    "build/src/**",
     "templates",
     "!build/src/**/*.map",
     "schemas"


### PR DESCRIPTION
## Problem

After #3, downstream consumers depending on this fork via git URL get `node_modules/release-please/build/` empty — imports like `release-please/build/src/github` fail.

## Cause

Two issues introduced by #3:

1. Adding `packageManager: yarn@4.15.0` makes yarn's git-fetcher use `yarn install && yarn pack`. Unlike npm, yarn 4 does **not** auto-run `prepare` on `yarn install`, so `build/` never gets compiled.
2. Yarn 4's pack reads `files: ["build/src"]` strictly (only matches the `main`/`bin` paths); npm and yarn-classic recursed implicitly.

## Fix

```diff
-"prepare": "yarn compile",
+"prepack": "tsc -p .",
```
```diff
-"build/src",
+"build/src/**",
```

`prepack` fires reliably on `yarn pack`. `tsc` runs from `node_modules/.bin/` — no npm or yarn needed on PATH.

## Verified

End-to-end against `grafana/loki-release` PR #349 pointed at this branch: `node_modules/release-please/build/src/` has 252 files, all 8 previously-failing imports resolve, and `yarn run actions:should-release` (the failing CI job) builds clean.